### PR TITLE
Add Meta Pixel and LinkedIn Insight Tag for retargeting

### DIFF
--- a/website/pages/_app.jsx
+++ b/website/pages/_app.jsx
@@ -1,12 +1,59 @@
 import '../styles/globals.css'
 import EmailPopup from '../components/EmailPopup'
+import Script from 'next/script'
 
 export default function App({ Component, pageProps }) {
   return (
     <>
+      {/* Meta Pixel */}
+      <Script id="meta-pixel" strategy="afterInteractive">
+        {`
+          !function(f,b,e,v,n,t,s)
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+          n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t,s)}(window, document,'script',
+          'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', '${process.env.NEXT_PUBLIC_META_PIXEL_ID}');
+          fbq('track', 'PageView');
+        `}
+      </Script>
+      <noscript>
+        <img
+          height="1"
+          width="1"
+          style={{ display: 'none' }}
+          src={`https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_META_PIXEL_ID}&ev=PageView&noscript=1`}
+          alt=""
+        />
+      </noscript>
+
+      {/* LinkedIn Insight Tag */}
+      <Script id="linkedin-insight" strategy="afterInteractive">
+        {`
+          _linkedin_partner_id = "${process.env.NEXT_PUBLIC_LINKEDIN_PARTNER_ID}";
+          window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+          window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+        `}
+      </Script>
+      <Script
+        src="https://snap.licdn.com/li.lms-analytics/insight.min.js"
+        strategy="afterInteractive"
+      />
+      <noscript>
+        <img
+          height="1"
+          width="1"
+          style={{ display: 'none' }}
+          alt=""
+          src={`https://px.ads.linkedin.com/collect/?pid=${process.env.NEXT_PUBLIC_LINKEDIN_PARTNER_ID}&fmt=gif`}
+        />
+      </noscript>
+
       <Component {...pageProps} />
       <EmailPopup />
     </>
   )
 }
-


### PR DESCRIPTION
## Summary
- Adds Meta Pixel for Facebook/Instagram retargeting ads
- Adds LinkedIn Insight Tag for LinkedIn ads and company insights
- Uses environment variables for pixel IDs (same as other sites)

## Environment Variables Required
```
NEXT_PUBLIC_META_PIXEL_ID=772575254789776
NEXT_PUBLIC_LINKEDIN_PARTNER_ID=511924030
```

## Test plan
- [ ] Verify Meta Pixel fires on page load (check FB Events Manager)
- [ ] Verify LinkedIn Insight Tag fires (check LinkedIn Campaign Manager)
- [ ] Confirm no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)