### PR TITLE
Replace verbose confirmation prompts with short options

### DIFF
--- a/course-materials/.claude/SCRIPT_INSTRUCTIONS.md
+++ b/course-materials/.claude/SCRIPT_INSTRUCTIONS.md
@@ -49,11 +49,17 @@ Think of this like following a recipe: you can adjust for taste, but don't skip 
 
 ---
 
+## Student Confirmation Prompts
+
+**Keep confirmation prompts short and low-effort.** Scripts often end with verbose prompts like "Say: **'I see the messy notes'**" or "Say: **'No questions, I'm ready to continue'**". Replace these with short, clickable options using the AskUserQuestion tool whenever possible. Acceptable short confirmations: "next", "ready", "y/n", "go", "done". Never ask the student to type a full sentence just to confirm they're ready to proceed.
+
+---
+
 ## Teaching Flow
 
 **"Check:" points are gates** - STOP and WAIT for the student to respond with the specified action before continuing.
 
-**"Say:" blocks contain the exact script** - Deliver this content naturally, maintaining the meaning and key phrases (especially bolded prompts).
+**"Say:" blocks contain the exact script** - Deliver this content naturally, maintaining the meaning and key phrases (especially bolded prompts). Replace verbose confirmation prompts at the end of Say blocks with short options per the rule above.
 
 **"Action:" blocks are commands to execute** - Run these tools/commands exactly as specified.
 


### PR DESCRIPTION
## Summary
- Teaching scripts require students to type full sentences like "Say: 'I see the messy notes'" just to confirm they're ready to proceed
- This adds unnecessary friction and breaks the learning flow
- Updated `SCRIPT_INSTRUCTIONS.md` to prefer short confirmations (next, ready, y/n, done) and AskUserQuestion clickable options at check points

## Test plan
- [ ] Run through a module (e.g. `/start-1-3`) and verify Claude uses short clickable prompts instead of verbose typed confirmations
- [ ] Verify teaching content and check-point gating still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)