### PR TITLE
feat: add a configurable video generation workflow

### DIFF
--- a/course-materials/.claude/commands/start-3-3-1.md
+++ b/course-materials/.claude/commands/start-3-3-1.md
@@ -1,0 +1,15 @@
+---
+description: "Module 3.3.1: Video Generation - Create and iterate on product videos"
+---
+
+**Do this SILENTLY:**
+
+1. Read `lesson-modules/3-nano-banana/3.3-video-generation/3.3.1-first-video/CLAUDE.md` - this is your teaching script
+
+2. Read `.claude/SCRIPT_INSTRUCTIONS.md` for critical teaching rules
+
+3. Follow the teaching script precisely as instructed:
+   - Execute "Say:" blocks word-for-word
+   - Stop at "Check:" points and wait
+   - Run "Action:" blocks exactly as specified
+   - Start teaching immediately (no meta-commentary)

--- a/course-materials/README.md
+++ b/course-materials/README.md
@@ -8,7 +8,7 @@ Welcome to the interactive Claude Code course for Product Managers!
 
 ### What's Included
 
-- **`lesson-modules/`** - Interactive modules taught by Claude (Modules 0-2)
+- **`lesson-modules/`** - Interactive modules taught by Claude (Modules 0-3)
 - **`company-context/`** - TaskFlow company reference materials for exercises
 - **`.claude/`** - Slash commands that power the course experience
 
@@ -53,6 +53,11 @@ This kicks off Module 1.1 - Welcome to Claude Code!
 - 2.1: Write a PRD
 - 2.2: Analyze Data
 - 2.3: Product Strategy
+
+**Module 3: Visual Generation**
+- 3.1: Image generation fundamentals
+- 3.2: PM visual use cases
+- 3.3.1: Video generation
 
 ### Slash Commands
 

--- a/course-materials/course-structure.json
+++ b/course-materials/course-structure.json
@@ -173,6 +173,15 @@
           "command": "start-3-2-3",
           "description": "Create app store graphics, social ads, and launch announcement visuals",
           "estimatedMinutes": 20
+        },
+        {
+          "id": "3.3.1",
+          "title": "Video Generation",
+          "slug": "video-generation",
+          "path": "lesson-modules/3-nano-banana/3.3-video-generation/3.3.1-first-video/CLAUDE.md",
+          "command": "start-3-3-1",
+          "description": "Generate and iterate on product videos from text or reference images",
+          "estimatedMinutes": 25
         }
       ]
     },

--- a/course-materials/lesson-modules/3-nano-banana/.env.example
+++ b/course-materials/lesson-modules/3-nano-banana/.env.example
@@ -1,1 +1,10 @@
 GEMINI_API_KEY=your_api_key_here
+
+# Video generation configuration
+MINIMAX_API_KEY=your_api_key_here
+MINIMAX_REGION=global_en
+MINIMAX_VIDEO_MODEL=your_video_model_here
+MINIMAX_GLOBAL_OPENAI_BASE_URL=https://api.minimax.io/v1
+MINIMAX_GLOBAL_ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+MINIMAX_CN_OPENAI_BASE_URL=https://api.minimaxi.com/v1
+MINIMAX_CN_ANTHROPIC_BASE_URL=https://api.minimaxi.com/anthropic

--- a/course-materials/lesson-modules/3-nano-banana/3.3-video-generation/3.3.1-first-video/CLAUDE.md
+++ b/course-materials/lesson-modules/3-nano-banana/3.3-video-generation/3.3.1-first-video/CLAUDE.md
@@ -1,0 +1,139 @@
+# Module 3.3.1: Video Generation
+
+Welcome to Module 3.3.1: Video Generation!
+
+You've already learned how to make strong product visuals. Now you'll turn a product idea or a still image into a short video that can be reviewed, iterated, and shared.
+
+STOP: Ready to create your first product video?
+
+USER: Yes / Ready
+
+---
+
+## Configure the Video Tool
+
+The video helper is `video_gen.py`. It uses the same workflow as the image helper: you describe the creative goal, Claude calls the helper, and the result is saved in `outputs/`.
+
+Before the first generation, make sure the `.env` file in this module's parent folder contains:
+
+```bash
+MINIMAX_API_KEY=your_api_key_here
+MINIMAX_REGION=global_en
+MINIMAX_VIDEO_MODEL=your_video_model_here
+```
+
+Use `MINIMAX_REGION=cn_zh` when the domestic endpoint is the right choice for your account. The helper keeps both region configurations available and uses the selected region for task creation, status polling, and file retrieval.
+
+STOP: Is your API key, region, and video model configured?
+
+USER: Yes / Configured
+
+---
+
+## Text-to-Video
+
+Video generation is asynchronous. The helper creates a task, checks its status, retrieves the completed file, and saves the `.mp4` output for you.
+
+STOP: Ask me to create a six-second product demo for TaskFlow Mobile. Describe the product, the user action, the camera movement, and the mood.
+
+USER: Create a product demo / Generate the video
+
+ACTION: Use `video_gen.py` to call `generate()` with:
+- The user's prompt
+- The configured `MINIMAX_VIDEO_MODEL`
+- `duration=6`
+- `resolution="768P"` unless the user requests another supported value
+- The configured `MINIMAX_REGION`
+- An output path inside the `outputs/` folder
+
+ACTION: Tell the user the absolute path to the saved `.mp4` file.
+
+Open the output in a video player and watch for three things: does the subject stay clear, does the motion support the product story, and does the ending leave room for a useful next action?
+
+STOP: What would you change in the first version?
+
+USER: [Describes a change]
+
+ACTION: Generate another version with the requested prompt change. Keep the same product goal unless the user asks for a new direction.
+
+ACTION: Provide the absolute path to the new output.
+
+---
+
+## Image-to-Video
+
+A strong still image can be the first frame of a video. This is useful when you already have a persona, mockup, launch graphic, or storyboard frame that should become a moving scene.
+
+STOP: Ask me to animate an existing product visual. Include the path to an image in this module or another accessible folder.
+
+USER: Animate this image / Turn this still into a video
+
+ACTION: Call `generate()` with:
+- `first_frame_image` set to the user's image path
+- A prompt describing the motion and camera behavior
+- The configured model, region, duration, and resolution
+
+ACTION: If the image is not available or does not meet the API's image requirements, explain the problem and ask for a supported JPG, JPEG, PNG, or WebP image smaller than 20 MB.
+
+ACTION: Provide the absolute path to the generated video.
+
+STOP: Does the motion preserve the original product or character clearly?
+
+USER: Yes / It needs changes
+
+ACTION: If changes are requested, revise only the motion, timing, or camera direction that the user named and generate another version.
+
+---
+
+## A Practical PM Video Workflow
+
+For real product work, use this sequence:
+
+1. **Storyboard:** Write the start state, key action, and end state before generating.
+2. **Draft:** Use a short duration and a lower resolution to test the idea quickly.
+3. **Review:** Check continuity, motion, framing, and whether the product value is obvious without narration.
+4. **Iterate:** Change one creative variable at a time.
+5. **Share:** Keep the strongest `.mp4` with a descriptive filename in `outputs/`.
+
+Video prompts work best when they name the subject, action, setting, camera behavior, lighting, duration, and intended audience. Avoid asking for a whole storyboard in one prompt when a sequence of short clips will be easier to review.
+
+STOP: What product moment would you prototype with a short video?
+
+USER: [Responds]
+
+ACTION: Help the user turn that moment into a concise prompt and generate the clip if they are ready.
+
+---
+
+## Wrap-Up
+
+You now have a repeatable video workflow:
+
+- Configure a region and model without changing the helper code
+- Generate from text or a reference image
+- Wait for asynchronous completion automatically
+- Review and iterate on the saved `.mp4`
+- Keep the best product story in an organized output folder
+
+The next module is Module 4.1, where you'll use Claude Code to set up a small product website.
+
+Type `/start-4-1` when you're ready to continue.
+
+---
+
+## Important Notes for Claude
+
+- Import `generate()` from `video_gen.py`; do not reimplement API calls in the teaching flow.
+- Pass the configured model explicitly when the user has set `MINIMAX_VIDEO_MODEL`.
+- Use the selected region for every create, query, and download request.
+- Always provide the absolute output path after a successful generation.
+- Do not claim a video was generated when the API call or polling step failed.
+
+## Success Criteria
+
+The module is complete when the student has:
+- [ ] Configured the video API key, region, and model
+- [ ] Generated a text-to-video product clip
+- [ ] Iterated on the clip after reviewing it
+- [ ] Understands how to animate a reference image
+- [ ] Knows where the generated `.mp4` files are saved

--- a/course-materials/lesson-modules/3-nano-banana/test_video_gen.py
+++ b/course-materials/lesson-modules/3-nano-banana/test_video_gen.py
@@ -1,0 +1,97 @@
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+sys.path.insert(0, str(Path(__file__).parent))
+import video_gen
+
+
+class CaptureHandler(BaseHTTPRequestHandler):
+    requests = []
+
+    def _write_json(self, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        self.requests.append((self.command, self.path, json.loads(body)))
+        self._write_json({"task_id": "task-123"})
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        self.requests.append((self.command, self.path, None))
+        query = parse_qs(parsed.query)
+        if parsed.path == "/v1/query/video_generation":
+            self._write_json({"task_id": query["task_id"][0], "status": "Success", "file_id": "file-123"})
+        elif parsed.path == "/v1/files/retrieve":
+            host, port = self.server.server_address
+            self._write_json({"file": {"download_url": f"http://{host}:{port}/video.mp4"}})
+        elif parsed.path == "/video.mp4":
+            body = b"video-bytes"
+            self.send_response(200)
+            self.send_header("Content-Type", "video/mp4")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+
+    def log_message(self, *_args):
+        return
+
+
+class VideoGenerationTest(unittest.TestCase):
+    def test_generate_captures_native_video_paths(self):
+        CaptureHandler.requests = []
+        server = ThreadingHTTPServer(("127.0.0.1", 0), CaptureHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        host, port = server.server_address
+        base_url = f"http://{host}:{port}"
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir, patch.dict(
+                os.environ,
+                {
+                    "MINIMAX_API_KEY": "test-key",
+                    "MINIMAX_REGION": "global_en",
+                    "MINIMAX_VIDEO_MODEL": "test-video-model",
+                    "MINIMAX_GLOBAL_OPENAI_BASE_URL": f"{base_url}/v1",
+                    "MINIMAX_GLOBAL_ANTHROPIC_BASE_URL": f"{base_url}/anthropic",
+                    "MINIMAX_CN_OPENAI_BASE_URL": f"{base_url}/v1",
+                    "MINIMAX_CN_ANTHROPIC_BASE_URL": f"{base_url}/anthropic",
+                },
+            ):
+                cn_endpoints = video_gen._region_endpoints("cn_zh")
+                self.assertEqual(cn_endpoints.anthropic_base_url, f"{base_url}/anthropic")
+                output_path = Path(temp_dir) / "result.mp4"
+                result = video_gen.generate("A product demo", poll_interval=0, timeout=2, output_path=str(output_path))
+                result_bytes = output_path.read_bytes()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        self.assertEqual(result, str(output_path))
+        self.assertEqual(result_bytes, b"video-bytes")
+        paths = [request[1] for request in CaptureHandler.requests]
+        self.assertEqual(paths[0], "/v1/video_generation")
+        self.assertTrue(paths[1].startswith("/v1/query/video_generation?task_id=task-123"))
+        self.assertTrue(paths[2].startswith("/v1/files/retrieve?file_id=file-123"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/course-materials/lesson-modules/3-nano-banana/video_gen.py
+++ b/course-materials/lesson-modules/3-nano-banana/video_gen.py
@@ -1,0 +1,290 @@
+"""
+MiniMax video generation helper for Claude Code.
+
+The helper creates an asynchronous video task, polls it until completion,
+retrieves the generated file, and saves the result in the outputs folder.
+"""
+import base64
+import json
+import mimetypes
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urljoin
+from urllib.request import Request, urlopen
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OUTPUT_DIR = "outputs"
+DEFAULT_REGION = "global_en"
+DEFAULT_DURATION = 6
+DEFAULT_POLL_INTERVAL = 10
+DEFAULT_TIMEOUT = 600
+VIDEO_GENERATION_PATH = "/v1/video_generation"
+VIDEO_QUERY_PATH = "/v1/query/video_generation"
+FILE_RETRIEVE_PATH = "/v1/files/retrieve"
+
+
+@dataclass(frozen=True)
+class RegionEndpoints:
+    region: str
+    openai_base_url: str
+    anthropic_base_url: str
+    video_base_url: str
+
+
+_REGION_ENV = {
+    "global_en": (
+        "MINIMAX_GLOBAL_OPENAI_BASE_URL",
+        "MINIMAX_GLOBAL_ANTHROPIC_BASE_URL",
+    ),
+    "cn_zh": (
+        "MINIMAX_CN_OPENAI_BASE_URL",
+        "MINIMAX_CN_ANTHROPIC_BASE_URL",
+    ),
+}
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} not found in environment. Check your .env file.")
+    return value
+
+
+def _native_video_base(openai_base_url: str) -> str:
+    base_url = openai_base_url.rstrip("/")
+    if not base_url.endswith("/v1"):
+        raise ValueError("The OpenAI-compatible base URL must end with /v1.")
+    return base_url[:-3]
+
+
+def _region_endpoints(region: str = None) -> RegionEndpoints:
+    selected_region = (region or os.environ.get("MINIMAX_REGION", DEFAULT_REGION)).strip()
+    if selected_region not in _REGION_ENV:
+        supported = ", ".join(_REGION_ENV)
+        raise ValueError(f"MINIMAX_REGION must be one of: {supported}")
+
+    openai_env, anthropic_env = _REGION_ENV[selected_region]
+    openai_base_url = _required_env(openai_env).rstrip("/")
+    anthropic_base_url = _required_env(anthropic_env).rstrip("/")
+    if not anthropic_base_url.endswith("/anthropic"):
+        raise ValueError("The Anthropic-compatible base URL must end with /anthropic.")
+
+    return RegionEndpoints(
+        region=selected_region,
+        openai_base_url=openai_base_url,
+        anthropic_base_url=anthropic_base_url,
+        video_base_url=_native_video_base(openai_base_url),
+    )
+
+
+def _request_json(
+    method: str,
+    path: str,
+    payload: dict = None,
+    region: str = None,
+    timeout: int = 120,
+) -> dict:
+    endpoints = _region_endpoints(region)
+    api_key = _required_env("MINIMAX_API_KEY")
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+
+    request = Request(
+        urljoin(f"{endpoints.video_base_url}/", path.lstrip("/")),
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            response_body = response.read().decode("utf-8")
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"MiniMax API request failed ({error.code}): {detail}") from error
+    except URLError as error:
+        raise RuntimeError(f"MiniMax API request failed: {error.reason}") from error
+
+    try:
+        return json.loads(response_body)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("MiniMax API returned invalid JSON.") from error
+
+
+def _image_reference(value: str) -> str:
+    if value.startswith(("http://", "https://", "data:image/")):
+        return value
+
+    image_path = Path(value)
+    if not image_path.is_file():
+        raise FileNotFoundError(f"Reference image not found: {value}")
+    if image_path.stat().st_size >= 20 * 1024 * 1024:
+        raise ValueError("Reference images must be smaller than 20 MB.")
+
+    mime_type = mimetypes.guess_type(image_path.name)[0] or "image/jpeg"
+    if mime_type not in {"image/jpeg", "image/png", "image/webp"}:
+        raise ValueError("Reference images must be JPG, JPEG, PNG, or WebP files.")
+
+    encoded = base64.b64encode(image_path.read_bytes()).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def create_task(
+    prompt: str,
+    model: str = None,
+    first_frame_image: str = None,
+    duration: int = DEFAULT_DURATION,
+    resolution: str = None,
+    prompt_optimizer: bool = True,
+    fast_pretreatment: bool = False,
+    callback_url: str = None,
+    region: str = None,
+) -> dict:
+    """Create a text-to-video or image-to-video generation task."""
+    if not prompt.strip():
+        raise ValueError("prompt must not be empty.")
+
+    selected_model = (model or os.environ.get("MINIMAX_VIDEO_MODEL", "")).strip()
+    if not selected_model:
+        raise ValueError("Pass model or set MINIMAX_VIDEO_MODEL in your .env file.")
+
+    payload = {
+        "model": selected_model,
+        "prompt": prompt,
+        "duration": duration,
+        "prompt_optimizer": prompt_optimizer,
+    }
+    if first_frame_image:
+        payload["first_frame_image"] = _image_reference(first_frame_image)
+    if resolution:
+        payload["resolution"] = resolution
+    if fast_pretreatment:
+        payload["fast_pretreatment"] = True
+    if callback_url:
+        payload["callback_url"] = callback_url
+
+    return _request_json("POST", VIDEO_GENERATION_PATH, payload, region=region)
+
+
+def query_task(task_id: str, region: str = None) -> dict:
+    """Return the current status for a video generation task."""
+    query = urlencode({"task_id": task_id})
+    return _request_json("GET", f"{VIDEO_QUERY_PATH}?{query}", region=region)
+
+
+def retrieve_file(file_id: str, region: str = None) -> dict:
+    """Retrieve metadata and a temporary download URL for a generated file."""
+    query = urlencode({"file_id": file_id})
+    return _request_json("GET", f"{FILE_RETRIEVE_PATH}?{query}", region=region)
+
+
+def download_video(file_id: str, output_path: str = None, region: str = None) -> str:
+    """Download a generated video and return its local path."""
+    file_response = retrieve_file(file_id, region=region)
+    download_url = file_response.get("file", {}).get("download_url")
+    if not download_url:
+        raise RuntimeError("MiniMax did not return a download URL for the generated video.")
+
+    if output_path:
+        destination = Path(output_path)
+    else:
+        Path(OUTPUT_DIR).mkdir(exist_ok=True)
+        destination = Path(OUTPUT_DIR) / f"video_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{file_id}.mp4"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    request = Request(download_url, headers={"Accept": "video/mp4"})
+    try:
+        with urlopen(request, timeout=120) as response:
+            destination.write_bytes(response.read())
+    except (HTTPError, URLError) as error:
+        raise RuntimeError(f"Video download failed: {error}") from error
+
+    print(f"Saved: {destination}")
+    return str(destination)
+
+
+def generate(
+    prompt: str,
+    model: str = None,
+    first_frame_image: str = None,
+    duration: int = DEFAULT_DURATION,
+    resolution: str = None,
+    prompt_optimizer: bool = True,
+    fast_pretreatment: bool = False,
+    callback_url: str = None,
+    region: str = None,
+    poll_interval: int = DEFAULT_POLL_INTERVAL,
+    timeout: int = DEFAULT_TIMEOUT,
+    output_path: str = None,
+) -> str:
+    """Create, wait for, and download a video generation task."""
+    task_response = create_task(
+        prompt=prompt,
+        model=model,
+        first_frame_image=first_frame_image,
+        duration=duration,
+        resolution=resolution,
+        prompt_optimizer=prompt_optimizer,
+        fast_pretreatment=fast_pretreatment,
+        callback_url=callback_url,
+        region=region,
+    )
+    task_id = task_response.get("task_id")
+    if not task_id:
+        raise RuntimeError("MiniMax did not return a task_id.")
+
+    print(f"Created video task: {task_id}")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status_response = query_task(task_id, region=region)
+        status = (status_response.get("status") or "").lower()
+        if status == "success":
+            file_id = status_response.get("file_id")
+            if not file_id:
+                raise RuntimeError("MiniMax marked the task successful without a file_id.")
+            return download_video(file_id, output_path=output_path, region=region)
+        if status in {"fail", "failed"}:
+            message = status_response.get("base_resp", {}).get("status_msg", "unknown error")
+            raise RuntimeError(f"MiniMax video generation failed: {message}")
+
+        print(f"Task status: {status or 'processing'}")
+        time.sleep(poll_interval)
+
+    raise TimeoutError(f"Video generation task timed out after {timeout} seconds.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a video with the configured MiniMax endpoint.")
+    parser.add_argument("prompt")
+    parser.add_argument("--model")
+    parser.add_argument("--first-frame-image")
+    parser.add_argument("--duration", type=int, default=DEFAULT_DURATION)
+    parser.add_argument("--resolution")
+    parser.add_argument("--region", choices=tuple(_REGION_ENV))
+    parser.add_argument("--output-path")
+    args = parser.parse_args()
+
+    print(
+        generate(
+            prompt=args.prompt,
+            model=args.model,
+            first_frame_image=args.first_frame_image,
+            duration=args.duration,
+            resolution=args.resolution,
+            region=args.region,
+            output_path=args.output_path,
+        )
+    )

--- a/website/pages/nano-banana/setup.mdx
+++ b/website/pages/nano-banana/setup.mdx
@@ -92,6 +92,9 @@ cd ~/Documents/claude-code-pm-course && claude
 - 3.2.2: Strategy & Architecture - Diagrams, matrices, roadmaps
 - 3.2.3: Marketing & Launch Assets - App store graphics, ads, announcements
 
+**Module 3.3: Video Generation**
+- 3.3.1: Video Generation - Create and iterate on product videos from text or reference images
+
 
 ## Troubleshooting
 

--- a/website/pages/nano-banana/video-generation.mdx
+++ b/website/pages/nano-banana/video-generation.mdx
@@ -1,0 +1,125 @@
+---
+title: "3.3.1: Video Generation"
+description: "Create and iterate on product videos from text prompts or reference images with Claude Code"
+keywords: "video generation, text to video, image to video, product video, claude code"
+---
+
+## 3.3.1: Video Generation
+
+- **Time to Complete:** 25 minutes
+- **Prerequisites:** Nano Banana setup and a configured video API key
+
+> **Start this module in Claude Code:** Run `/start-3-3-1` to begin the interactive experience.
+
+## Overview
+
+This module adds a practical video workflow to the visual generation toolkit. You will create a short product clip from text, optionally animate a reference image, and iterate on the result.
+
+**Key takeaway:** Video generation is asynchronous. A reliable workflow creates a task, polls its status, retrieves the completed file, and saves the result so you can review it before deciding what to change.
+
+## Configure the Helper
+
+The course includes `video_gen.py` in the Nano Banana module folder. Copy the example environment file to `.env` and fill in the values for your account:
+
+```bash
+MINIMAX_API_KEY=your_api_key_here
+MINIMAX_REGION=global_en
+MINIMAX_VIDEO_MODEL=your_video_model_here
+```
+
+The helper supports both configured regions:
+
+| Region | OpenAI-compatible base | Anthropic-compatible base |
+|---|---|---|
+| `global_en` | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| `cn_zh` | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+The native video requests use the selected OpenAI-compatible base as their root and append the documented paths. The Anthropic-compatible values remain available for compatible text clients and are kept with the same region configuration.
+
+## Text-to-Video
+
+Ask Claude Code for a concise product moment rather than a full production. Include:
+
+- The subject and starting state
+- The action that should happen
+- Camera movement or framing
+- Lighting and mood
+- Duration and resolution
+
+The helper sends a task to `/v1/video_generation`, polls `/v1/query/video_generation`, retrieves the file through `/v1/files/retrieve`, and saves the resulting `.mp4` in `outputs/`.
+
+Example call:
+
+```python
+from video_gen import generate
+
+output_path = generate(
+    prompt="A product manager opens a clear mobile task board and assigns the next task to the team, gentle push-in camera movement, bright office light",
+    model="your_video_model_here",
+    duration=6,
+    resolution="768P",
+    region="global_en",
+)
+print(output_path)
+```
+
+The function waits for completion and returns the local path. Open that file in a video player before requesting changes.
+
+## Image-to-Video
+
+Use `first_frame_image` when you already have a product visual or storyboard frame:
+
+```python
+output_path = generate(
+    prompt="The interface gently animates as the user completes the highlighted task, steady camera, preserve the original layout",
+    model="your_video_model_here",
+    first_frame_image="outputs/taskflow_dashboard.png",
+    duration=6,
+    region="global_en",
+)
+```
+
+Reference images must be JPG, JPEG, PNG, or WebP files smaller than 20 MB. A public image URL or a supported data URL can also be passed directly.
+
+## Iteration Checklist
+
+Review each draft for:
+
+1. **Continuity:** Does the subject remain recognizable from start to finish?
+2. **Motion:** Does the camera or subject movement support the product message?
+3. **Framing:** Is the important interface or action visible throughout the clip?
+4. **Ending:** Does the final frame leave enough room for a caption or call to action?
+
+Change one variable at a time. Short drafts are easier to compare than a single long generation that tries to cover every scene.
+
+## Product Manager Use Cases
+
+- Prototype a feature walkthrough before engineering work begins
+- Animate a launch visual for a stakeholder review
+- Turn a persona or storyboard frame into a lightweight concept clip
+- Test different camera directions for a marketing brief
+- Create a short before-and-after concept for a product pitch
+
+## Troubleshooting
+
+### The helper cannot find an API key
+
+Confirm that the `.env` file is in the Nano Banana module folder and contains `MINIMAX_API_KEY`.
+
+### The region configuration is rejected
+
+Use `global_en` or `cn_zh` for `MINIMAX_REGION`. Make sure the selected OpenAI-compatible base ends in `/v1` and the selected Anthropic-compatible base ends in `/anthropic`.
+
+### The task keeps processing
+
+Video generation is asynchronous and can take longer than an image request. The helper waits up to its configured timeout and raises an error instead of returning an incomplete file.
+
+### The reference image is rejected
+
+Use a JPG, JPEG, PNG, or WebP image smaller than 20 MB with a suitable aspect ratio and a short edge above 300 pixels.
+
+## Resources
+
+- [MiniMax global documentation](https://platform.minimax.io/docs)
+- [MiniMax China documentation](https://platform.minimaxi.com/docs)
+- [Course materials](https://github.com/carlvellotti/claude-code-pm-course)

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -21,6 +21,7 @@
 <url><loc>https://ccforpms.com/nano-banana/style-database</loc><lastmod>2025-12-11T17:20:22.036Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://ccforpms.com/nano-banana/understanding-basics</loc><lastmod>2025-12-11T17:20:22.036Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://ccforpms.com/nano-banana/users-product-visuals</loc><lastmod>2025-12-11T17:20:22.036Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://ccforpms.com/nano-banana/welcome-first-generation</loc><lastmod>2025-12-11T17:20:22.036Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://ccforpms.com/search</loc><lastmod>2025-12-11T17:20:22.036Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://ccforpms.com/nano-banana/video-generation</loc><lastmod>2026-07-16T07:05:55.251Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://ccforpms.com/nano-banana/welcome-first-generation</loc><lastmod>2025-12-11T17:20:22.035Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://ccforpms.com/search</loc><lastmod>2025-12-11T17:20:22.035Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary
- Add an asynchronous video helper for text-to-video and image-to-video workflows.
- Preserve both configured regions, task polling, file retrieval, and focused request-path coverage.
- Add the interactive course module, website page, source navigation entry, and sitemap entry.

## Checks
- `.venv-octopatch/bin/python -m pip install -r course-materials/requirements.txt`
- `npm ci`
- `.venv-octopatch/bin/python -m py_compile course-materials/lesson-modules/3-nano-banana/video_gen.py course-materials/lesson-modules/3-nano-banana/test_video_gen.py`
- `.venv-octopatch/bin/python -m unittest discover -s course-materials/lesson-modules/3-nano-banana -p 'test_*.py'`
- `python3 -m json.tool course-materials/course-structure.json`
- `NODE_OPTIONS=--no-experimental-webstorage npm run build`